### PR TITLE
Initial test enablement for LLM Compressor

### DIFF
--- a/src/axolotl/train.py
+++ b/src/axolotl/train.py
@@ -25,7 +25,7 @@ from axolotl.contribs.lgpl.unsloth import (  # pylint: disable = no-name-in-modu
 from axolotl.logging_config import configure_logging
 from axolotl.utils.dict import DictDefault
 from axolotl.utils.freeze import freeze_layers_except
-from axolotl.utils.models import load_model, load_processor, load_tokenizer
+from axolotl.utils.models import load_model, load_processor, load_tokenizer, load_teacher
 from axolotl.utils.trainer import setup_trainer
 
 try:
@@ -98,6 +98,8 @@ def train(
     if model.generation_config is not None:
         model.generation_config.do_sample = True
 
+    teacher = load_teacher(cfg, tokenizer)
+
     model_ref = None
     if cfg.rl and cfg.rl != "orpo":
         if cfg.adapter and not cfg.rl_adapter_ref_model:
@@ -123,6 +125,7 @@ def train(
         tokenizer,
         processor,
         total_num_steps,
+        teacher,
     )
 
     if cfg.fix_untrained_tokens:

--- a/src/axolotl/utils/models.py
+++ b/src/axolotl/utils/models.py
@@ -1203,6 +1203,27 @@ def load_model(
     return loader.load_model()
 
 
+def load_teacher(
+    cfg: DictDefault,
+    tokenizer: PreTrainedTokenizerBase,
+) -> Optional[PreTrainedModel]:
+    """
+    Load a teacher model for a given configuration and tokenizer.
+    """
+    if not cfg.compressor or not cfg.compressor.teacher:
+        return None
+
+    loader = ModelLoader(
+        cfg.compressor.teacher,
+        tokenizer,
+        inference=True,
+        reference_model=True,
+    )
+    teacher, _ = loader.load_model()
+
+    return teacher
+
+
 def load_adapter(model, cfg, adapter, inference=False):
     # type: (PreTrainedModel, DictDefault, Optional[str], bool) -> Tuple[PreTrainedModel, Optional[PeftConfig]]
 

--- a/src/axolotl/utils/trainer.py
+++ b/src/axolotl/utils/trainer.py
@@ -513,14 +513,14 @@ def prepare_opinionated_env(cfg):
 
 
 def setup_trainer(
-    cfg, train_dataset, eval_dataset, model, tokenizer, processor, total_num_steps
+    cfg, train_dataset, eval_dataset, model, tokenizer, processor, total_num_steps, teacher
 ):
     if cfg.rl in ("dpo", "ipo", "orpo", "kto", "simpo"):
         trainer_builder = HFRLTrainerBuilder(cfg, model[0], tokenizer, processor)
         trainer_builder.model_ref = model[1]
         trainer_builder.peft_config = model[2]
     else:
-        trainer_builder = HFCausalTrainerBuilder(cfg, model[0], tokenizer, processor)
+        trainer_builder = HFCausalTrainerBuilder(cfg, model[0], tokenizer, processor, teacher)
 
     trainer_builder.train_dataset = train_dataset
     trainer_builder.eval_dataset = eval_dataset


### PR DESCRIPTION
Still needs to be significantly tested, but starting point to play around with for LLM Compressor. This enables the session mixin for control of the training graph, loading of a teacher, and passing through everything within the axolotl training config.

Example config addition on top of the base config here https://github.com/axolotl-ai-cloud/axolotl/tree/main/examples/llama-3/fft-8b.yaml:
```yaml
....

compressor:
  recipe:
    finetuning_stage:
      run_type: train
      pruning_modifiers:
        ConstantPruningModifier:
          targets: '__ALL__'
          start: 0
  recipe_args: {}
  teacher:
    base_model: NousResearch/Meta-Llama-3.1-8B
    load_in_8bit: false
    load_in_4bit: false
    strict: false
    flash_attention: true
```

after setting up the config file, use the following command:
`axolotl train CONFIG.yaml`